### PR TITLE
channel settings: Align long channel names with margins.

### DIFF
--- a/web/styles/subscriptions.css
+++ b/web/styles/subscriptions.css
@@ -588,6 +588,7 @@ h4.user_group_setting_subsection_title {
             .user-group-info-title {
                 display: none;
                 font-size: 1.5em;
+                margin: 0px 24px;
                 line-height: 1;
                 font-weight: 600;
                 word-break: break-all;


### PR DESCRIPTION
Fixes: #33455
<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.
Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->
This issue involves solving long channel names that were misaligned in the title area of the channel settings UI.
This change adds left and right margins to ensure alignment with other UI elements.

I tested two different approaches for this issue. The first was the method mentioned in the description, while the second involved manually changing the font size using the CSS property. This helped me understand how the title would look while leaving the rest of the text unchanged.

**Screenshots and screen captures:**
1. With a font size of 14 - 
![413424210-7574c196-c218-40b0-8f01-fc7b9d2b258d](https://github.com/user-attachments/assets/8ae0ebca-ff09-4941-b0a9-8364e5b01f56)
![413424349-4e3833bd-9f35-4cad-b16e-ebd8c6721a36](https://github.com/user-attachments/assets/98bb01fc-b384-421f-bb34-4f9ba69ada11)

2. With a font size of 16 - 
![413424555-007497a7-fb1b-4e89-a084-e441d77ccf10](https://github.com/user-attachments/assets/fff30919-c454-4480-a88f-f0137796f04e)
![413424657-69816fab-f2d6-43d9-b848-8e2506f5278c](https://github.com/user-attachments/assets/24565dc2-e05d-4ca0-99f4-7274c3550ef3)

3. With a font size of 20 - 
![413425206-49a928d0-37fa-4439-a5a2-1146628100df](https://github.com/user-attachments/assets/447e19d5-7854-4d25-8730-725dd4b74410)
![413425288-fde9bd1b-21ee-4364-965f-314a06c2a4b1](https://github.com/user-attachments/assets/c07d6a4d-1e71-4cca-a4c7-1e86697977ab)

<summary>Self-review checklist</summary>
<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [ ] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [ ] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [ ] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [ ] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [ ] Visual appearance of the changes.
- [ ] Responsiveness and internationalization.
- [ ] Strings and tooltips.
- [ ] End-to-end functionality of buttons, interactions and flows.
- [ ] Corner cases, error conditions, and easily imagined bugs.
</details>
